### PR TITLE
New option enabling the sending of <enter> after text

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Note: just like `x11-repl`, this finds the correct window by the window name. So
 
 | Switch      | Description                                  |
 | ----------- | -------------------------------------------- |
-| -send-enter | Send a keystroke of \<enter> after the text. |
+| -send-enter | Send a keystroke of \<enter> after the text. NOTE: Could be replaced if a similar feature is adopted in default plugins. |
 
 ## Screenshots
 

--- a/README.md
+++ b/README.md
@@ -48,15 +48,11 @@ If the module [`x11-repl`](https://github.com/mawww/kakoune/blob/master/rc/windo
 
 The method for sending text mirrors that of `x11-repl`, which means copying to the primary clipboard and pasting (`wl-clipboard`) with emulated `shift+insert` (`ydotool`). `jq` is used for parsing Sway data. Any suggestions for improving this are welcome.
 
-Note: Just like `x11-repl`, this finds the correct window by the window name. Some applications, like `fish` will rename the window by default, and thus break this. Therefore, run the repl with `:repl <repl-executable>` to avoid this.
+Note: just like `x11-repl`, this finds the correct window by the window name. Some applications, like `fish` will rename the window by default, and thus break this. Therefore, run the repl with `:repl <repl-executable>` to avoid this.
 
-## Configuration
-
-kakoune-sway declares the following options.
-
-| Name            | Type | Default | Description                                                                       |
-| --------------- | ---- | ------- | --------------------------------------------------------------------------------- |
-| repl_send_enter | bool | false   | When true, text sent to the REPL window will be followed by an \<enter> keystroke. |
+| Switch      | Description                                  |
+| ----------- | -------------------------------------------- |
+| -send-enter | Send a keystroke of \<enter> after the text. |
 
 ## Screenshots
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ set-option global windowing_modules 'x11'
 - `sway-new-up` ↑ new window above
 - `sway-new-down` ↓ new window below
 
-New windows display a *cloned view*: same buffer, same line.
+New windows display a _cloned view_: same buffer, same line.
 
 A `sway` user-mode is also declared. With the mapping in the Install section above:
 
@@ -49,6 +49,14 @@ If the module [`x11-repl`](https://github.com/mawww/kakoune/blob/master/rc/windo
 The method for sending text mirrors that of `x11-repl`, which means copying to the primary clipboard and pasting (`wl-clipboard`) with emulated `shift+insert` (`ydotool`). `jq` is used for parsing Sway data. Any suggestions for improving this are welcome.
 
 Note: Just like `x11-repl`, this finds the correct window by the window name. Some applications, like `fish` will rename the window by default, and thus break this. Therefore, run the repl with `:repl <repl-executable>` to avoid this.
+
+## Configuration
+
+kakoune-sway declares the following options.
+
+| Name            | Type | Default | Description                                                                       |
+| --------------- | ---- | ------- | --------------------------------------------------------------------------------- |
+| repl_send_enter | bool | false   | When true, text sent to the REPL window will be followed by an \<enter> keystroke. |
 
 ## Screenshots
 

--- a/sway.kak
+++ b/sway.kak
@@ -74,18 +74,18 @@ try %{ eval %sh{ [ -z "$SWAYSOCK" ] && echo fail " " }
     sway-send-text %{
       nop %sh{
         if [ $# -eq 0 ]; then
-          TEXT="$kak_selection"
+          text="$kak_selection"
         else
-          TEXT="$*"
+          text="$*"
         fi
 
-        PASTE_KEYSTROKE="shift+insert"
-        [ "$kak_opt_repl_send_enter" = "true" ] && PASTE_KEYSTROKE="$PASTE_KEYSTROKE enter"
+        paste_keystroke="shift+insert"
+        [ "$kak_opt_repl_send_enter" = "true" ] && paste_keystroke="$paste_keystroke enter"
 
         CUR_ID=$(swaymsg -t get_tree | jq -r "recurse(.nodes[]?) | select(.focused == true).id")
         swaymsg "[title=kak_repl_window] focus" &&
-        echo -n "$TEXT" | wl-copy --paste-once --primary &&
-        ydotool key $PASTE_KEYSTROKE >/dev/null 2>&1 &&
+        echo -n "$text" | wl-copy --paste-once --primary &&
+        ydotool key $paste_keystroke >/dev/null 2>&1 &&
         swaymsg "[con_id=$CUR_ID] focus"
       }
     }

--- a/sway.kak
+++ b/sway.kak
@@ -57,7 +57,10 @@ map global sway j :sway-new-down<ret> -docstring '↓ new window below'
 
 #map global user 3 ': enter-user-mode sway<ret>' -docstring 'sway…'
 
-# Sway support for send-text using ydotool:
+# Sway support for send-text using ydotool
+
+declare-option -docstring "Send <enter> after text." bool repl_send_enter false
+
 try %{ eval %sh{ [ -z "$SWAYSOCK" ] && echo fail " " }
   hook -once global ModuleLoaded x11-repl %sh{
     if ! { command -v ydotool && command -v jq && command -v wl-copy && command -v wl-paste; } >/dev/null
@@ -75,10 +78,14 @@ try %{ eval %sh{ [ -z "$SWAYSOCK" ] && echo fail " " }
         else
           TEXT="$*"
         fi
+
+        PASTE_KEYSTROKE="shift+insert"
+        [ "$kak_opt_repl_send_enter" = "true" ] && PASTE_KEYSTROKE="$PASTE_KEYSTROKE enter"
+
         CUR_ID=$(swaymsg -t get_tree | jq -r "recurse(.nodes[]?) | select(.focused == true).id")
         swaymsg "[title=kak_repl_window] focus" &&
         echo -n "$TEXT" | wl-copy --paste-once --primary &&
-        ydotool key shift+insert >/dev/null 2>&1 &&
+        ydotool key $PASTE_KEYSTROKE >/dev/null 2>&1 &&
         swaymsg "[con_id=$CUR_ID] focus"
       }
     }


### PR DESCRIPTION
This new `repl_send_enter` option defaults to false, preserving the current behaviour and consistency with other send-text implementations for Kakoune.  Setting it to true is a big advantage for some REPL workflows e.g. my own in IPython.  

Related:

https://github.com/mawww/kakoune/commit/e1db59fb8d2721d5b5be7d1a10bfef78701dcc93