### PR TITLE
Specify text/plain MIME type for wl-copy to prevent bad guess hanging.

### DIFF
--- a/sway.kak
+++ b/sway.kak
@@ -86,11 +86,11 @@ Switches:
           text="$*"
         fi
 
-        CUR_ID=$(swaymsg -t get_tree | jq -r "recurse(.nodes[]?) | select(.focused == true).id")
+        cur_id=$(swaymsg -t get_tree | jq -r "recurse(.nodes[]?) | select(.focused == true).id")
         swaymsg "[title=kak_repl_window] focus" &&
-        echo -n "$text" | wl-copy --paste-once --primary &&
+        echo -n "$text" | wl-copy --type text/plain --paste-once --primary &&
         ydotool key $paste_keystroke >/dev/null 2>&1 &&
-        swaymsg "[con_id=$CUR_ID] focus"
+        swaymsg "[con_id=$cur_id] focus"
       }
     }
     alias global send-text sway-send-text


### PR DESCRIPTION
Some input strings cause wl-copy to misidentify the MIME type of the
data being copied.  It can then hang waiting for more data even when
it already has all of the user's text.  This patch explicitly sets
the MIME type expected by wl-copy to text/plain.